### PR TITLE
flask based REST api for generating event hash

### DIFF
--- a/Dockerfile.webapi
+++ b/Dockerfile.webapi
@@ -1,0 +1,13 @@
+FROM python:3.8-alpine
+
+RUN apk --no-cache --update add bash inotify-tools curl
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+RUN pip install -r requirements.txt
+
+EXPOSE 5000/tcp
+
+COPY . /usr/src/app/
+ENTRYPOINT ["python3", "/usr/src/app/webapi/api.py"]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,24 @@ cd tests; pytest
 ```
 where pytests needs to be intalles (`pip install pytest`).
 
+Build webapi docker image
+
+```
+docker build . -f Dockerfile.webapi -t event-hash-generator
+```
+
+Run container
+
+```
+ docker run -p 5000:5000 event-hash-generator
+```
+
+Sample request (note: replace {..} with full json/json-ld event payload)
+
+```
+curl --location --request -POST 'http://localhost:5000/hash' --header 'Content-Type: application/json' --data-raw '{..}'
+```
+
 ## Introduction  
 There are situations in which organisations require to uniquely refer to a specific EPCIS event. For instance, companies may only want to store the <b>hash value of a given EPCIS event on a distributed shared ledger ('blockchain')</b> instead of any actual payload. Digitally signed and in conjunction with a unique timestamp, this is a powerful and effective way to prove the integrity of the underlying event data. Another use case consists to use such an approach to <b>populate the eventID field with values that are intrinsic to the EPCIS event</b> - if an organisation captures an event without an eventID (which is not required as of the standard) and sends that event to a business partner who needs to assign a unique ID, they can agree that the business partner populates the eventID field applying this methodology before storing the event on the server. If the organisation later wants to query for that specific event, it knows how the eventID was created, thus is able to query for it through the eventID value.
 EPCIS events have a couple of differences to other electronic documents:

--- a/epcis_event_hash_generator/hash_generator.py
+++ b/epcis_event_hash_generator/hash_generator.py
@@ -29,7 +29,9 @@ except ImportError:
     from context import epcis_event_hash_generator  # noqa: F401
 
 from epcis_event_hash_generator.xml_to_py import event_list_from_epcis_document_xml as read_xml
+from epcis_event_hash_generator.xml_to_py import event_list_from_epcis_document_xml_str as read_xml_str
 from epcis_event_hash_generator.json_to_py import event_list_from_epcis_document_json as read_json
+from epcis_event_hash_generator.json_to_py import event_list_from_epcis_document_json_str as read_json_str
 from epcis_event_hash_generator import PROP_ORDER
 
 
@@ -147,6 +149,28 @@ def compute_prehash_from_file(path, enforce=None):
     else:
         logging.error("Filename '%s' ending not recognized.", path)
 
+    return compute_prehash_from_events(events)
+
+
+def compute_prehash_from_json_str(jsonStr):
+    """Read EPCIS document and generate pre-hashe strings.
+    Use enforce = "XML" or "JSON" to ignore file ending.
+    """
+
+    events = read_json_str(jsonStr)
+
+    return compute_prehash_from_events(events)
+
+
+def compute_prehash_from_xml_str(xmlStr):
+    """Read EPCIS document and generate pre-hashe strings.
+    Use enforce = "XML" or "JSON" to ignore file ending.
+    """
+    events = read_xml_str(xmlStr.decode("utf-8"))
+    return compute_prehash_from_events(events)
+
+
+def compute_prehash_from_events(events):
     logging.info("#events = %s", len(events[2]))
     for i in range(len(events[2])):
         logging.info("%s: %s\n", i, events[2][i])
@@ -165,8 +189,17 @@ def compute_prehash_from_file(path, enforce=None):
 
     # To see/check concatenated value string before hash algorithm is performed:
     logging.debug("prehash_string_list = {}".format(prehash_string_list))
-
     return prehash_string_list
+
+
+def epcis_hash_from_json(json, hashalg="sha256"):
+    prehash_string_list = compute_prehash_from_json_str(json)
+    return calculate_hash(prehash_string_list, hashalg)
+
+
+def epcis_hash_from_xml(xmlStr, hashalg="sha256"):
+    prehash_string_list = compute_prehash_from_xml_str(xmlStr)
+    return calculate_hash(prehash_string_list, hashalg)
 
 
 def epcis_hash(path, hashalg="sha256"):
@@ -177,7 +210,10 @@ def epcis_hash(path, hashalg="sha256"):
     """
     prehash_string_list = compute_prehash_from_file(path)
 
-    # Calculate hash values and prefix them according to RFC 6920
+    return calculate_hash(prehash_string_list, hashalg)
+
+
+def calculate_hash(prehash_string_list, hashalg="sha256"):
     hashValueList = []
     for pre_hash_string in prehash_string_list:
         if hashalg == 'sha256':

--- a/epcis_event_hash_generator/json_to_py.py
+++ b/epcis_event_hash_generator/json_to_py.py
@@ -69,6 +69,7 @@ def namespace_replace(key):
 
     return key
 
+
 def collect_namespaces_from_jsonld_context(context):
     global _namespaces
 
@@ -81,6 +82,7 @@ def collect_namespaces_from_jsonld_context(context):
         else:
             for key in c.keys():
                 _namespaces[key] = c[key]
+
 
 def json_to_py(json_obj):
     """ Recursively convert a string/list/dict to a simple python object
@@ -132,6 +134,11 @@ def event_list_from_epcis_document_json(path):
     """
     with open(path, 'r') as file:
         data = file.read()
+
+    return event_list_from_epcis_document_json_str(data)
+
+
+def event_list_from_epcis_document_json_str(data):
 
     json_obj = json.loads(data)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 python_dateutil==2.8.1
+Flask==1.1.2

--- a/webapi/api.py
+++ b/webapi/api.py
@@ -1,0 +1,37 @@
+import os
+import sys
+from flask import Flask, abort, request
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+
+app = Flask(__name__)
+app.config["DEBUG"] = True
+
+
+@app.route('/', methods=['GET'])
+def home():
+    return "<h1>Welcome to event hash generator</h1><p>Use POST /hash endpoint to generate hash of your event</p>"
+
+
+@app.route('/health', methods=['GET'])
+def health():
+    return "IMOK"
+
+
+@app.route('/hash', methods=['POST'])
+def hash():
+
+    from epcis_event_hash_generator import hash_generator
+
+    if request.content_type == 'application/json':
+        (hashes, prehashes) = hash_generator.epcis_hash_from_json(request.data)
+        return ",".join(hashes)
+    elif request.content_type == 'application/xml':
+        (hashes, prehashes) = hash_generator.epcis_hash_from_xml(request.data)
+        return ",".join(hashes)
+    else:
+        return abort(404, "Invalid content_type in request")
+
+
+app.run(host='0.0.0.0')


### PR DESCRIPTION
Hi @RalphTro and @Echsecutor, 

As part of EPCIS 2.0 prototype, we intend to integrate this event hash generator. It would be nice to treat it as an internal micro service which exposes REST endpoint for generating hash of EPCIS event passed as part of request.

To be able to achieve that, I have added flask based REST api under webapi directory and also added required files to prepare docker container which will make the deployment in various environments consistent.

Please suggest if any parts required improvement or not in-line with normal python development.

Looking forward to your feedback.

Cheers,
Bhavesh 