### PR TITLE
structural refacturing to improve modularization fixes #46

### DIFF
--- a/epcis_event_hash_generator/context.py
+++ b/epcis_event_hash_generator/context.py
@@ -1,6 +1,5 @@
+import epcis_event_hash_generator
 import os
 import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
-import epcis_event_hash_generator

--- a/epcis_event_hash_generator/dl_normaliser.py
+++ b/epcis_event_hash_generator/dl_normaliser.py
@@ -440,6 +440,6 @@ def normaliser(uri):
         match(r'https:\/\/id.gs1.org\/8010\/([\x23\x2D\x2F\x30-\x39\x41-\x5A]{0,30})$', uri) or
         match(r'https:\/\/id.gs1.org\/8017\/(\d{18})$', uri) or
         match(r'https:\/\/id.gs1.org\/8018\/(\d{18})$', uri)
-    ) is not None: # noqa E124
+    ) is not None:  # noqa E124
         return (uri)
     return None

--- a/epcis_event_hash_generator/events_from_file_reader.py
+++ b/epcis_event_hash_generator/events_from_file_reader.py
@@ -1,0 +1,63 @@
+""" Read EPCIS events from a JSON(-LD) or XML file and convert them into a simple puthon object via the apropriate conversion module. See json_to_py / xml_to_py for details.
+
+.. module:: events_from_file_reader
+
+.. moduleauthor:: Ralph Troeger <ralph.troeger@gs1.de>, Sebastian Schmittner <schmittner@eecc.info>
+
+Copyright 2020 Ralph Troeger, Sebastian Schmittner
+
+This program is free software: you can redistribute it and/or modify
+it under the terms given in the LICENSE file.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the LICENSE
+file for details.
+
+"""
+import logging
+
+try:
+    from .context import epcis_event_hash_generator
+except ImportError:
+    from context import epcis_event_hash_generator  # noqa: F401
+
+from epcis_event_hash_generator import json_to_py
+from epcis_event_hash_generator import xml_to_py
+
+
+def _event_list_from_epcis_document_xml(path):
+    """Read EPCIS XML document and generate the event List in the form of a simple python object
+
+    """
+    with open(path, 'r') as file:
+        data = file.read()
+
+    return xml_to_py.event_list_from_epcis_document_str(data)
+
+
+def _event_list_from_epcis_document_json(path):
+    """Read EPCIS JSON document and generate the event List in the form of a simple python object
+
+    """
+    with open(path, 'r') as file:
+        data = file.read()
+
+    return json_to_py.event_list_from_epcis_document_str(data)
+
+
+def event_list_from_file(path, enforce=""):
+    """Read all EPCIS Events from the EPCIS document at path.
+    Return a python object representation of the contained events.
+
+    Use enforce "XML" or "JSON" to ignore the file ending and parse the
+    specified format.
+    """
+
+    if enforce == "XML" or path.lower().endswith(".xml"):
+        return _event_list_from_epcis_document_xml(path)
+    elif enforce == "JSON" or path.lower().endswith(".json") or path.lower().endswith(".jsonld"):
+        return _event_list_from_epcis_document_json(path)
+    else:
+        logging.error("Filename '%s' ending not recognized.", path)
+        return None

--- a/epcis_event_hash_generator/events_from_file_reader.py
+++ b/epcis_event_hash_generator/events_from_file_reader.py
@@ -1,4 +1,5 @@
-""" Read EPCIS events from a JSON(-LD) or XML file and convert them into a simple puthon object via the apropriate conversion module. See json_to_py / xml_to_py for details.
+""" Read EPCIS events from a JSON(-LD) or XML file and convert them into a simple puthon object
+via the apropriate conversion module. See json_to_py / xml_to_py for details.
 
 .. module:: events_from_file_reader
 

--- a/epcis_event_hash_generator/hash_generator.py
+++ b/epcis_event_hash_generator/hash_generator.py
@@ -30,17 +30,16 @@ except ImportError:
     from context import epcis_event_hash_generator  # noqa: F401
 
 from epcis_event_hash_generator.dl_normaliser import normaliser as dl_normaliser
-from epcis_event_hash_generator.xml_to_py import event_list_from_epcis_document_xml as read_xml
-from epcis_event_hash_generator.xml_to_py import event_list_from_epcis_document_xml_str as read_xml_str
-from epcis_event_hash_generator.json_to_py import event_list_from_epcis_document_json as read_json
-from epcis_event_hash_generator.json_to_py import event_list_from_epcis_document_json_str as read_json_str
+from epcis_event_hash_generator.events_from_file_reader import event_list_from_file
+from epcis_event_hash_generator.xml_to_py import event_list_from_epcis_document_str as read_xml_str
+from epcis_event_hash_generator.json_to_py import event_list_from_epcis_document_str as read_json_str
 from epcis_event_hash_generator import PROP_ORDER
 from epcis_event_hash_generator import JOIN_BY as DEFAULT_JOIN_BY
 
 JOIN_BY = DEFAULT_JOIN_BY
 
 
-def fix_time_stamp_format(timestamp):
+def _fix_time_stamp_format(timestamp):
     """Make sure that the timestamp is given at millisecond precision
     and in UTC."""
     logging.debug("correcting timestamp format for '{}'".format(timestamp))
@@ -60,17 +59,17 @@ def fix_time_stamp_format(timestamp):
     return fixed
 
 
-def child_to_pre_hash_string(child, sub_child_order):
+def _child_to_pre_hash_string(child, sub_child_order):
     text = ""
     grand_child_text = ""
     if sub_child_order:
-        grand_child_text = recurse_through_children_in_order(child[2], sub_child_order)
+        grand_child_text = _recurse_through_children_in_order(child[2], sub_child_order)
     if child[1]:
         text = child[1].strip()
         if child[0].lower().find("time") > 0 and child[0].lower().find("offset") < 0:
-            text = fix_time_stamp_format(text)
+            text = _fix_time_stamp_format(text)
         else:
-            text = canonize_value(text)
+            text = _canonize_value(text)
 
         if text:
             text = "=" + text
@@ -82,7 +81,7 @@ def child_to_pre_hash_string(child, sub_child_order):
     return ""
 
 
-def recurse_through_children_in_order(child_list, child_order):
+def _recurse_through_children_in_order(child_list, child_order):
     """
     Loop over child order, look for a child of root with matching key and build the pre-hash string (mostly key=value)
     Recurse through the grand children applying the sub order.
@@ -101,7 +100,7 @@ def recurse_through_children_in_order(child_list, child_order):
         list_of_values = []
 
         for child in children:
-            child_pre_hash = child_to_pre_hash_string(child, sub_child_order)
+            child_pre_hash = _child_to_pre_hash_string(child, sub_child_order)
             if child_pre_hash:
                 list_of_values.append(child_pre_hash)
             else:
@@ -124,10 +123,10 @@ def recurse_through_children_in_order(child_list, child_order):
     return pre_hash
 
 
-def canonize_value(text):
+def _canonize_value(text):
     """Run a value through all format canonizations"""
-    text = try_format_web_vocabulary(text)
-    text = try_format_numeric(text)
+    text = _try_format_web_vocabulary(text)
+    text = _try_format_numeric(text)
     converted = dl_normaliser(text)
     if converted:
         logging.debug("Converted %s to %s", text, converted)
@@ -135,7 +134,7 @@ def canonize_value(text):
     return text
 
 
-def try_format_web_vocabulary(text):
+def _try_format_web_vocabulary(text):
     """Replace old CBV URNs by new web vocabulary equivalents."""
     return text.replace(
         'urn:epcglobal:cbv:bizstep:', 'https://ns.gs1.org/voc/Bizstep-'
@@ -148,7 +147,7 @@ def try_format_web_vocabulary(text):
     ).replace('urn:epcglobal:cbv:er:', 'https://ns.gs1.org/voc/ER-')
 
 
-def try_format_numeric(text):
+def _try_format_numeric(text):
     """remove leading/trailing zeros, leading "+", etc. from numbers. Non numeric values are left untouched."""
     try:
         numeric = float(text)
@@ -160,7 +159,7 @@ def try_format_numeric(text):
     return text
 
 
-def generic_child_list_to_prehash_string(children):
+def _generic_child_list_to_prehash_string(children):
     list_of_values = []
 
     logging.debug("Parsing remaining elements in: %s", children)
@@ -168,15 +167,15 @@ def generic_child_list_to_prehash_string(children):
     for child in children:
         text = child[1].strip()
         if text:
-            text = canonize_value(text)
+            text = _canonize_value(text)
             text = "=" + text
-        list_of_values.append(child[0] + text + generic_child_list_to_prehash_string(child[2]))
+        list_of_values.append(child[0] + text + _generic_child_list_to_prehash_string(child[2]))
 
     list_of_values.sort()
     return JOIN_BY.join(list_of_values)
 
 
-def gather_elements_not_in_order(children, child_order):
+def _gather_elements_not_in_order(children, child_order):
     """
     Collects vendor extensions not covered by the defined child order. Consumes the root.
     """
@@ -188,45 +187,22 @@ def gather_elements_not_in_order(children, child_order):
         if child[0] in to_be_ignored:
             children.remove(child)
     if children:
-        return generic_child_list_to_prehash_string(children)
+        return _generic_child_list_to_prehash_string(children)
 
     return ""
 
 
-def compute_prehash_from_file(path, enforce=None):
-    """Read EPCIS document and generate pre-hash strings.
-    Use enforce = "XML" or "JSON" to ignore file ending and use JSON/XML parser.
+def derive_prehashes_from_events(events, join_by=DEFAULT_JOIN_BY):
     """
-    if enforce == "XML" or path.lower().endswith(".xml"):
-        events = read_xml(path)
-    elif enforce == "JSON" or path.lower().endswith(".json") or path.lower().endswith(".jsonld"):
-        events = read_json(path)
-    else:
-        logging.error("Filename '%s' ending not recognized.", path)
-        return None
-
-    return compute_prehash_from_events(events)
-
-
-def compute_prehash_from_json_str(jsonStr):
-    """Read EPCIS document and generate pre-hash strings.
-    Use enforce = "XML" or "JSON" to ignore file ending.
+    Compute a normalized form (pre-hash string) for each event.
+    This is the main functionality of the hash generator.
     """
 
-    events = read_json_str(jsonStr)
+    global JOIN_BY
+    join_by = join_by.replace(r"\n", "\n").replace(r"\t", "\t")
+    logging.debug("Setting JOIN_BY='%s'", join_by)
+    JOIN_BY = join_by
 
-    return compute_prehash_from_events(events)
-
-
-def compute_prehash_from_xml_str(xmlStr):
-    """Read EPCIS document and generate pre-hash strings.
-    Use enforce = "XML" or "JSON" to ignore file ending.
-    """
-    events = read_xml_str(xmlStr.decode("utf-8"))
-    return compute_prehash_from_events(events)
-
-
-def compute_prehash_from_events(events):
     logging.info("#events = %s", len(events[2]))
     for i in range(len(events[2])):
         logging.info("%s: %s\n", i, events[2][i])
@@ -236,8 +212,8 @@ def compute_prehash_from_events(events):
         logging.debug("prehashing event:\n%s", event)
         try:
             prehash_string_list.append("eventType=" + event[0] + JOIN_BY
-                                       + recurse_through_children_in_order(event[2], PROP_ORDER) + JOIN_BY
-                                       + gather_elements_not_in_order(event[2], PROP_ORDER)
+                                       + _recurse_through_children_in_order(event[2], PROP_ORDER) + JOIN_BY
+                                       + _gather_elements_not_in_order(event[2], PROP_ORDER)
                                        )
         except Exception as ex:
             logging.error("could not parse event:\n%s\n\nerror: %s", event, ex)
@@ -249,32 +225,9 @@ def compute_prehash_from_events(events):
     return prehash_string_list
 
 
-def epcis_hash_from_json(json, hashalg="sha256"):
-    prehash_string_list = compute_prehash_from_json_str(json)
-    return calculate_hash(prehash_string_list, hashalg)
-
-
-def epcis_hash_from_xml(xmlStr, hashalg="sha256"):
-    prehash_string_list = compute_prehash_from_xml_str(xmlStr)
-    return calculate_hash(prehash_string_list, hashalg)
-
-
-def epcis_hash(path, hashalg="sha256", join_by=DEFAULT_JOIN_BY):
-    """Read all EPCIS Events from the EPCIS XML document at path.
-    Compute a normalized form (pre-hash string) for each event and
-    return an array of the event hashes computed from the pre-hash by
-    hashalg.
+def calculate_hashes_from_pre_hashes(prehash_string_list, hashalg="sha256"):
+    """Hash all strings in the list with the given algorithm. Returned in the appropriate NI format.
     """
-    global JOIN_BY
-    join_by = join_by.replace(r"\n", "\n").replace(r"\t", "\t")
-    logging.debug("Setting JOIN_BY='%s'", join_by)
-    JOIN_BY = join_by
-    prehash_string_list = compute_prehash_from_file(path)
-
-    return calculate_hash(prehash_string_list, hashalg)
-
-
-def calculate_hash(prehash_string_list, hashalg="sha256"):
     hashValueList = []
     for pre_hash_string in prehash_string_list:
         if hashalg == 'sha256':
@@ -294,4 +247,14 @@ def calculate_hash(prehash_string_list, hashalg="sha256"):
 
         hashValueList.append(hash_string)
 
-    return hashValueList, prehash_string_list
+    return hashValueList
+
+
+def epcis_hashes_from_events(events):
+    """Calculate the list of hashes from the given events list 
+    + hashing algorithm through the pre hash string using default parameters.
+    """
+    prehash_string_list = derive_prehashes_from_events(events)
+    return calculate_hashes_from_pre_hashes(prehash_string_list)
+
+

--- a/epcis_event_hash_generator/hash_generator.py
+++ b/epcis_event_hash_generator/hash_generator.py
@@ -30,9 +30,6 @@ except ImportError:
     from context import epcis_event_hash_generator  # noqa: F401
 
 from epcis_event_hash_generator.dl_normaliser import normaliser as dl_normaliser
-from epcis_event_hash_generator.events_from_file_reader import event_list_from_file
-from epcis_event_hash_generator.xml_to_py import event_list_from_epcis_document_str as read_xml_str
-from epcis_event_hash_generator.json_to_py import event_list_from_epcis_document_str as read_json_str
 from epcis_event_hash_generator import PROP_ORDER
 from epcis_event_hash_generator import JOIN_BY as DEFAULT_JOIN_BY
 
@@ -251,10 +248,8 @@ def calculate_hashes_from_pre_hashes(prehash_string_list, hashalg="sha256"):
 
 
 def epcis_hashes_from_events(events):
-    """Calculate the list of hashes from the given events list 
+    """Calculate the list of hashes from the given events list
     + hashing algorithm through the pre hash string using default parameters.
     """
     prehash_string_list = derive_prehashes_from_events(events)
     return calculate_hashes_from_pre_hashes(prehash_string_list)
-
-

--- a/epcis_event_hash_generator/json_to_py.py
+++ b/epcis_event_hash_generator/json_to_py.py
@@ -1,4 +1,5 @@
-"""Convert an EventList contained in an EPCIS 2.0 document in JSON LD format into a simple python object.
+"""Convert an EventList contained in an EPCIS 2.0 document in JSON LD format into a simple python object
+via the main method event_list_from_epcis_document_str.
 
 See the description of xml_to_py for more details about what 'simple' means here.
 
@@ -59,7 +60,7 @@ from epcis_event_hash_generator import json_xml_model_mismatch_correction
 _namespaces = {}  # global dictionary gathered during parsing
 
 
-def namespace_replace(key):
+def _namespace_replace(key):
     """If the key contains a namespace (followed by ":"), replace it with
     the {naemspace_url} from the _namespaces dict.
     """
@@ -70,7 +71,7 @@ def namespace_replace(key):
     return key
 
 
-def collect_namespaces_from_jsonld_context(context):
+def _collect_namespaces_from_jsonld_context(context):
     global _namespaces
 
     if not(isinstance(context, str)):
@@ -84,7 +85,7 @@ def collect_namespaces_from_jsonld_context(context):
                 _namespaces[key] = "{" + c[key] + "}"
 
 
-def json_to_py(json_obj):
+def _json_to_py(json_obj):
     """ Recursively convert a string/list/dict to a simple python object
     """
     global _namespaces
@@ -93,7 +94,7 @@ def json_to_py(json_obj):
 
     if isinstance(json_obj, list):
         for child in json_obj:
-            py_obj[2].append(json_to_py(child))
+            py_obj[2].append(_json_to_py(child))
     elif isinstance(json_obj, dict):
         if "isA" in json_obj:
             py_obj = (json_obj["isA"], "", [])
@@ -107,12 +108,12 @@ def json_to_py(json_obj):
                 _namespaces[key[7:]] = "{" + val + "}"
                 logging.debug("Namespaces: %s", _namespaces)
 
-                py_obj = (namespace_replace(py_obj[0]), py_obj[1], py_obj[2])
+                py_obj = (_namespace_replace(py_obj[0]), py_obj[1], py_obj[2])
             else:
                 # first find namespaces in child, then replace in key!
-                child = json_to_py(val)
+                child = _json_to_py(val)
 
-                key = namespace_replace(key)
+                key = _namespace_replace(key)
 
                 if isinstance(val, list):
                     for element in child[2]:
@@ -129,22 +130,15 @@ def json_to_py(json_obj):
     return py_obj
 
 
-def event_list_from_epcis_document_json(path):
-    """Read EPCIS JSON document and generate the event List in the form of a simple python object
-
+def event_list_from_epcis_document_str(data):
     """
-    with open(path, 'r') as file:
-        data = file.read()
-
-    return event_list_from_epcis_document_json_str(data)
-
-
-def event_list_from_epcis_document_json_str(data):
+    Parse the JSON str data and convert to a simple python object. Apply the format corrections to match what we get from the respective xml representation.
+    """
 
     json_obj = json.loads(data)
 
     if not(json_obj.get("@context") is None):
-        collect_namespaces_from_jsonld_context(json_obj["@context"])
+        _collect_namespaces_from_jsonld_context(json_obj["@context"])
 
     if "eventList" in json_obj["epcisBody"]:
         event_list = json_obj["epcisBody"]["eventList"]
@@ -156,6 +150,6 @@ def event_list_from_epcis_document_json_str(data):
 
     # Correct JSON/XML data model mismatch
     for event in event_list:
-        events.append(json_xml_model_mismatch_correction.deep_structure_correction(json_to_py(event)))
+        events.append(json_xml_model_mismatch_correction.deep_structure_correction(_json_to_py(event)))
 
     return ("EventList", "", events)

--- a/epcis_event_hash_generator/json_to_py.py
+++ b/epcis_event_hash_generator/json_to_py.py
@@ -132,7 +132,8 @@ def _json_to_py(json_obj):
 
 def event_list_from_epcis_document_str(data):
     """
-    Parse the JSON str data and convert to a simple python object. Apply the format corrections to match what we get from the respective xml representation.
+    Parse the JSON str data and convert to a simple python object.
+    Apply the format corrections to match what we get from the respective xml representation.
     """
 
     json_obj = json.loads(data)

--- a/epcis_event_hash_generator/xml_to_py.py
+++ b/epcis_event_hash_generator/xml_to_py.py
@@ -69,7 +69,7 @@ import xml.etree.ElementTree as ElementTree
 
 def _remove_extension_tags(data):
     """
-    Remove useless EPCIS extension tags from a string 
+    Remove useless EPCIS extension tags from a string
     """
     return data.replace('<extension>', '').replace('</extension>', '').replace(
         '<baseExtension>', '').replace('</baseExtension>', '')

--- a/epcis_event_hash_generator/xml_to_py.py
+++ b/epcis_event_hash_generator/xml_to_py.py
@@ -1,4 +1,5 @@
-"""Convert an EventList contained in an EPCIS 2.0 document in XML format into a simple python object.
+"""Convert an EventList contained in an EPCIS 2.0 document in XML format into a simple python object
+via the main method event_list_from_epcis_document_str.
 
 A simple object here may be a
 - string
@@ -66,19 +67,10 @@ import logging
 import xml.etree.ElementTree as ElementTree
 
 
-def _read_epcis_document_xml(path):
-    """Read XML file, remove useless EPCIS extension tags and return the parsed root of the ElementTree.
+def _remove_extension_tags(data):
     """
-    with open(path, 'r') as file:
-        data = file.read()
-
-    data = removeExtensionTags(data)
-    logging.debug("removed extensions tags:\n%s", data)
-
-    return ElementTree.fromstring(data)
-
-
-def removeExtensionTags(data):
+    Remove useless EPCIS extension tags from a string 
+    """
     return data.replace('<extension>', '').replace('</extension>', '').replace(
         '<baseExtension>', '').replace('</baseExtension>', '')
 
@@ -108,22 +100,12 @@ def _xml_to_py(root, sort=True):
     return obj
 
 
-def event_list_from_epcis_document_xml(path):
-    """Read EPCIS XML document and generate the event List in the form of a simple python object
-
-    """
-    with open(path, 'r') as file:
-        data = file.read()
-
-    return event_list_from_epcis_document_xml_str(data)
-
-
-def event_list_from_epcis_document_xml_str(xmlStr):
+def event_list_from_epcis_document_str(xmlStr):
     """
     Read EPCIS XML document and generate the event List in the form of a simple python object
     """
     try:
-        data = removeExtensionTags(xmlStr)
+        data = _remove_extension_tags(xmlStr)
 
         root = ElementTree.fromstring(data)
 
@@ -131,7 +113,7 @@ def event_list_from_epcis_document_xml_str(xmlStr):
         if not eventList:
             raise ValueError("No EventList found")
     except (ValueError, OSError) as ex:
-        logging.debug(ex)
+        logging.error(ex)
         logging.error("Input string does not contain a valid EPCIS XML document with EventList.")
         return ("", "", [])
 

--- a/tests/test_explicit_hash_values.py
+++ b/tests/test_explicit_hash_values.py
@@ -5,7 +5,7 @@ except ImportError:
 
 from os import walk, path
 
-from epcis_event_hash_generator.hash_generator import epcis_hash
+from epcis_event_hash_generator.__main__ import epcis_hash_from_file
 
 TEST_FILE_PATH = "examples/"
 
@@ -16,7 +16,7 @@ def test_explicit_hash_values():
         for filename in filenames:
             if filename.endswith("xml") or filename.endswith("json") or filename.endswith("jsonld"):
                 print("Testing file " + filename)
-                actualHashes = epcis_hash(TEST_FILE_PATH + filename, "sha256")[0]
+                actualHashes = epcis_hash_from_file(TEST_FILE_PATH + filename, "sha256")[0]
                 assert len(actualHashes) > 0
                 with open(TEST_FILE_PATH + path.splitext(filename)[0] + '.hashes', 'r') as expectedfile:
                     expectedHashes = expectedfile.read().splitlines()

--- a/tests/test_required_properties.py
+++ b/tests/test_required_properties.py
@@ -5,7 +5,7 @@ except ImportError:
 
 from os import walk
 
-from epcis_event_hash_generator.hash_generator import epcis_hash
+from epcis_event_hash_generator.__main__ import epcis_hash_from_file
 
 TEST_FILE_PATH = "examples/"
 TEST_FILE_PATH_SAME_EVENT = "expected_equal/"
@@ -20,7 +20,7 @@ def test_distinct():
     for (_, _, filenames) in walk(TEST_FILE_PATH):
         for filename in filenames:
             if filename.endswith("xml"):
-                all_hashes += epcis_hash(TEST_FILE_PATH + filename, "sha256")[0]
+                all_hashes += epcis_hash_from_file(TEST_FILE_PATH + filename, "sha256")[0]
         break
 
     assert all_hashes
@@ -39,7 +39,7 @@ def test_equal():
     for (_, _, filenames) in walk(TEST_FILE_PATH_SAME_EVENT):
         for filename in filenames:
             if filename.endswith("xml") or filename.endswith("json") or filename.endswith("jsonld"):
-                assert len(set(epcis_hash(TEST_FILE_PATH_SAME_EVENT + filename, "sha256")[
+                assert len(set(epcis_hash_from_file(TEST_FILE_PATH_SAME_EVENT + filename, "sha256")[
                     0])) == 1, "The events in {} have different hashes!".format(
                     TEST_FILE_PATH_SAME_EVENT + filename)
         break

--- a/tests/test_xml_to_py.py
+++ b/tests/test_xml_to_py.py
@@ -5,7 +5,8 @@ except ImportError:
 
 import xml.etree.ElementTree as ElementTree
 
-from epcis_event_hash_generator import xml_to_py
+from epcis_event_hash_generator.events_from_file_reader import event_list_from_file
+from epcis_event_hash_generator.xml_to_py import _xml_to_py
 
 
 def test_docstring_example():
@@ -24,13 +25,13 @@ def test_docstring_example():
                                ("c", "", [("d", "Hello", []), ("d", "World", [("x", "y", [])]), ("e", "f", [])])]),
                     ("d", "2", [])]
 
-    actual_obj = xml_to_py._xml_to_py(ElementTree.fromstring(xml))
+    actual_obj = _xml_to_py(ElementTree.fromstring(xml))
 
     assert expected_obj == actual_obj[2]
 
 
 def test_epcsi_reference_example():
-    actual_obj = xml_to_py.event_list_from_epcis_document_xml("examples/ReferenceEventHashAlgorithm.xml")
+    actual_obj = event_list_from_file("examples/ReferenceEventHashAlgorithm.xml")
 
     print(actual_obj)
 

--- a/webapi/api.py
+++ b/webapi/api.py
@@ -30,7 +30,7 @@ def hash():
         events = xml_to_py.event_list_from_epcis_document_str(request.data.decode("utf-8"))
     else:
         return abort(404, "Invalid content_type in request")
-    
+
     hashes = hash_generator.epcis_hashes_from_events(events)
     return ",".join(hashes)
 

--- a/webapi/api.py
+++ b/webapi/api.py
@@ -22,16 +22,17 @@ def health():
 @app.route('/hash', methods=['POST'])
 def hash():
 
-    from epcis_event_hash_generator import hash_generator
+    from epcis_event_hash_generator import hash_generator, json_to_py, xml_to_py
 
     if request.content_type == 'application/json' or request.content_type == 'application/ld+json':
-        (hashes, prehashes) = hash_generator.epcis_hash_from_json(request.data)
-        return ",".join(hashes)
+        events = json_to_py.event_list_from_epcis_document_str(request.data.decode("utf-8"))
     elif request.content_type == 'application/xml':
-        (hashes, prehashes) = hash_generator.epcis_hash_from_xml(request.data)
-        return ",".join(hashes)
+        events = xml_to_py.event_list_from_epcis_document_str(request.data.decode("utf-8"))
     else:
         return abort(404, "Invalid content_type in request")
+    
+    hashes = hash_generator.epcis_hashes_from_events(events)
+    return ",".join(hashes)
 
 
 app.run(host='0.0.0.0')


### PR DESCRIPTION
This refacturing yields a better separation of concerns into modules

- xml/json parsing to python is done in the xml/json to py modules
- atop file reading happens in the events from file reader
- the hash generator now only does the hashing
- a high level method `epcis_hash_from_file` in `__main__` puts things together